### PR TITLE
Validate records locally against schema before submitting ?

### DIFF
--- a/amo2kinto/importer.py
+++ b/amo2kinto/importer.py
@@ -31,6 +31,12 @@ def sync_records(amo_records, fields,
     amo_records = prepare_amo_records(amo_records, fields)
 
     if schema:
+        # We validate all amo_records to make sure nothing is broken
+        # if we were to import everything.
+        #
+        # We could be validating only to_create records below but it
+        # is a sane safety check.
+        #
         for record in amo_records:
             jsonschema.validate(record, schema)
 

--- a/amo2kinto/importer.py
+++ b/amo2kinto/importer.py
@@ -1,5 +1,6 @@
 import codecs
 import json
+import jsonschema
 import requests
 import six
 
@@ -28,6 +29,11 @@ def sync_records(amo_records, fields,
                  kinto_client, bucket, collection, schema, permissions):
 
     amo_records = prepare_amo_records(amo_records, fields)
+
+    if schema:
+        for record in amo_records:
+            jsonschema.validate(record, schema)
+
     kinto_records = get_kinto_records(
         kinto_client=kinto_client,
         bucket=bucket,

--- a/amo2kinto/tests/test_importer.py
+++ b/amo2kinto/tests/test_importer.py
@@ -2,7 +2,10 @@ import codecs
 import json
 import mock
 import os
+import pytest
 import unittest
+
+from jsonschema.exceptions import ValidationError
 
 from amo2kinto import constants
 from amo2kinto.importer import FIELDS, prepare_amo_records, sync_records, main
@@ -205,12 +208,13 @@ def test_certificate_record():
 
 
 def test_sync_records_calls_the_scenario():
+    prepared_records = []
     with mock.patch(
             'amo2kinto.importer.get_kinto_records',
             return_value=mock.sentinel.kinto_records) as get_kinto_records:
         with mock.patch(
                 'amo2kinto.importer.prepare_amo_records',
-                return_value=mock.sentinel.prepared_records) as p_amo_records:
+                return_value=prepared_records) as p_amo_records:
             with mock.patch(
                     'amo2kinto.importer.get_diff',
                     return_value=(
@@ -219,7 +223,9 @@ def test_sync_records_calls_the_scenario():
                 with mock.patch(
                         'amo2kinto.importer.push_changes') as push_changes:
 
-                    sync_records(mock.sentinel.amo_records,
+                    amo_records = []
+
+                    sync_records(amo_records,
                                  mock.sentinel.fields,
                                  mock.sentinel.kinto_client,
                                  mock.sentinel.bucket,
@@ -228,7 +234,7 @@ def test_sync_records_calls_the_scenario():
                                  mock.sentinel.permissions)
 
                     p_amo_records.assert_called_with(
-                        mock.sentinel.amo_records,
+                        amo_records,
                         mock.sentinel.fields)
 
                     get_kinto_records.assert_called_with(
@@ -239,7 +245,7 @@ def test_sync_records_calls_the_scenario():
                         permissions=mock.sentinel.permissions)
 
                     get_diff.assert_called_with(
-                        mock.sentinel.prepared_records,
+                        prepared_records,
                         mock.sentinel.kinto_records)
 
                     push_changes.assert_called_with(
@@ -272,6 +278,37 @@ RECORDS_FILE = os.path.join(os.path.dirname(__file__),
                             'fixtures', 'blocklists.json')
 with codecs.open(RECORDS_FILE, encoding='utf-8') as f:
     RECORDS = json.load(f)
+
+
+def test_sync_records_validate_records_against_schema():
+    with mock.patch(
+            'amo2kinto.importer.get_kinto_records',
+            return_value=[]):
+        with mock.patch('amo2kinto.importer.push_changes'):
+
+            sync_records(RECORDS['addons'],
+                         FIELDS['addons'],
+                         mock.sentinel.kinto_client,
+                         mock.sentinel.bucket,
+                         mock.sentinel.collection,
+                         SCHEMAS['addons'],
+                         mock.sentinel.permissions)
+
+
+def test_sync_records_validate_records_against_schema_and_fails_if_wrong():
+    with mock.patch(
+            'amo2kinto.importer.get_kinto_records',
+            return_value=[]):
+        with mock.patch('amo2kinto.importer.push_changes'):
+
+            with pytest.raises(ValidationError):
+                sync_records(RECORDS['gfx'],
+                             FIELDS['gfx'],
+                             mock.sentinel.kinto_client,
+                             mock.sentinel.bucket,
+                             mock.sentinel.collection,
+                             SCHEMAS['addons']['config']['schema'],
+                             mock.sentinel.permissions)
 
 
 class TestMain(unittest.TestCase):

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ with codecs.open(os.path.join(HERE, 'CHANGELOG.rst'), encoding='utf-8') as f:
 
 
 REQUIREMENTS = [
+    'jsonschema',
     'kinto-client',
     'requests',
     'lxml',


### PR DESCRIPTION
Currently the scripts assumes that the server will validate the schema.

It should either check that the server has the json validation capability, or validate records locally before submitting them