### PR TITLE
The kinto-writer draft collection should not be publicly readable.

### DIFF
--- a/amo2kinto/constants.py
+++ b/amo2kinto/constants.py
@@ -10,7 +10,7 @@ ADDONS_SERVER = 'https://addons-dev.allizom.org/'
 # Kinto server defaults
 KINTO_SERVER = 'http://localhost:8888/v1'
 AUTH = ('mark', 'p4ssw0rd')
-COLLECTION_PERMISSIONS = {'read': ["system.Everyone"]}
+COLLECTION_PERMISSIONS = {}
 
 # Buckets name default
 ADDONS_BUCKET = u'staging'


### PR DESCRIPTION
kinto-signer is responsible for creating the public collection with read for everyone permissions.

The one we are importing in is not supposed to be public.

r? @leplatrem 