### PR TITLE
Do not use session_kwargs anymore.

### DIFF
--- a/amo2kinto/synchronize.py
+++ b/amo2kinto/synchronize.py
@@ -51,7 +51,7 @@ def push_changes(diff, kinto_client, bucket, collection):
     to_create, to_update, to_delete = diff
 
     logger.warn('Syncing to {}{}'.format(
-        kinto_client.session_kwargs['server_url'],
+        kinto_client.session.server_url,
         kinto_client.endpoints.get(
             'records', bucket=bucket, collection=collection)))
 


### PR DESCRIPTION
``session_kwargs`` has been removed from the last release of kinto-http