### PR TITLE
Add a configurable signoff workflow to-review → to-sign (fixes #47)

### DIFF
--- a/amo2kinto/importer.py
+++ b/amo2kinto/importer.py
@@ -4,7 +4,7 @@ import jsonschema
 import requests
 import six
 
-from kinto_http import cli_utils
+from kinto_http import cli_utils, Client
 from six.moves.urllib.parse import urljoin
 
 from . import constants
@@ -25,7 +25,8 @@ FIELDS = {
 }
 
 
-def sync_records(amo_records, fields, kinto_client, bucket, collection, config, permissions):
+def sync_records(amo_records, fields, kinto_client, editor_client, reviewer_client,
+                 bucket, collection, config, permissions):
 
     amo_records = prepare_amo_records(amo_records, fields)
 
@@ -48,8 +49,8 @@ def sync_records(amo_records, fields, kinto_client, bucket, collection, config, 
 
     to_create, to_update, to_delete = get_diff(amo_records, kinto_records)
 
-    push_changes((to_create, to_update, to_delete), kinto_client,
-                 bucket=bucket, collection=collection)
+    push_changes((to_create, to_update, to_delete), kinto_client, editor_client,
+                 reviewer_client, bucket=bucket, collection=collection)
 
 
 def main(args=None):
@@ -67,6 +68,14 @@ def main(args=None):
 
     parser.add_argument('--no-schema', help='Should we handle schemas',
                         action="store_true")
+
+    parser.add_argument('--editor-auth',
+                        help='Credentials to be used for requesting a review',
+                        type=str, default=None)
+
+    parser.add_argument('--reviewer-auth',
+                        help='Credentials to be used for validating the review',
+                        type=str, default=None)
 
     parser.add_argument('--certificates-bucket',
                         help='Bucket name for certificates',
@@ -118,6 +127,22 @@ def main(args=None):
     args = parser.parse_args(args=args)
     cli_utils.setup_logger(logger, args)
 
+    kinto_client = cli_utils.create_client_from_args(args)
+
+    if args.editor_auth is None:
+        args.editor_auth = args.auth
+    else:
+        args.editor_auth = tuple(args.editor_auth.split(':', 1))
+    editor_client = Client(server_url=args.server,
+                           auth=args.editor_auth)
+
+    if args.reviewer_auth is None:
+        args.reviewer_auth = args.auth
+    else:
+        args.reviewer_auth = tuple(args.reviewer_auth.split(':', 1))
+    reviewer_client = Client(server_url=args.server,
+                             auth=args.reviewer_auth)
+
     # If none of the different "collections" were passed as parameter, then we
     # want to import them all.
     import_all = not any([
@@ -125,8 +150,6 @@ def main(args=None):
         args.gfx,
         args.addons,
         args.plugins])
-
-    kinto_client = cli_utils.create_client_from_args(args)
 
     # Check if the schema capability is activated
     body, headers = kinto_client.session.request('get', '/')
@@ -161,6 +184,8 @@ def main(args=None):
             sync_records(amo_records=records,
                          fields=FIELDS[collection_type],
                          kinto_client=kinto_client,
+                         editor_client=editor_client,
+                         reviewer_client=reviewer_client,
                          bucket=bucket,
                          collection=collection,
                          config=config,

--- a/amo2kinto/importer.py
+++ b/amo2kinto/importer.py
@@ -181,6 +181,7 @@ def main(args=None):
             config = None
             if collection_type in schemas:
                 config = schemas[collection_type]['config']
+            print editor_client, kinto_client
             sync_records(amo_records=records,
                          fields=FIELDS[collection_type],
                          kinto_client=kinto_client,

--- a/amo2kinto/importer.py
+++ b/amo2kinto/importer.py
@@ -25,8 +25,9 @@ FIELDS = {
 }
 
 
-def sync_records(amo_records, fields, kinto_client, editor_client, reviewer_client,
-                 bucket, collection, config, permissions):
+def sync_records(amo_records, fields, kinto_client,
+                 bucket, collection, config, permissions,
+                 editor_client=None, reviewer_client=None):
 
     amo_records = prepare_amo_records(amo_records, fields)
 
@@ -49,8 +50,9 @@ def sync_records(amo_records, fields, kinto_client, editor_client, reviewer_clie
 
     to_create, to_update, to_delete = get_diff(amo_records, kinto_records)
 
-    push_changes((to_create, to_update, to_delete), kinto_client, editor_client,
-                 reviewer_client, bucket=bucket, collection=collection)
+    push_changes((to_create, to_update, to_delete), kinto_client,
+                 bucket=bucket, collection=collection,
+                 editor_client=editor_client, reviewer_client=reviewer_client)
 
 
 def main(args=None):
@@ -129,19 +131,17 @@ def main(args=None):
 
     kinto_client = cli_utils.create_client_from_args(args)
 
-    if args.editor_auth is None:
-        args.editor_auth = args.auth
-    else:
+    editor_client = None
+    if args.editor_auth is not None:
         args.editor_auth = tuple(args.editor_auth.split(':', 1))
-    editor_client = Client(server_url=args.server,
-                           auth=args.editor_auth)
+        editor_client = Client(server_url=args.server,
+                               auth=args.editor_auth)
 
-    if args.reviewer_auth is None:
-        args.reviewer_auth = args.auth
-    else:
+    reviewer_client = None
+    if args.reviewer_auth is not None:
         args.reviewer_auth = tuple(args.reviewer_auth.split(':', 1))
-    reviewer_client = Client(server_url=args.server,
-                             auth=args.reviewer_auth)
+        reviewer_client = Client(server_url=args.server,
+                                 auth=args.reviewer_auth)
 
     # If none of the different "collections" were passed as parameter, then we
     # want to import them all.

--- a/amo2kinto/importer.py
+++ b/amo2kinto/importer.py
@@ -181,7 +181,6 @@ def main(args=None):
             config = None
             if collection_type in schemas:
                 config = schemas[collection_type]['config']
-            print editor_client, kinto_client
             sync_records(amo_records=records,
                          fields=FIELDS[collection_type],
                          kinto_client=kinto_client,

--- a/amo2kinto/synchronize.py
+++ b/amo2kinto/synchronize.py
@@ -47,18 +47,19 @@ def get_diff(source, dest):
             [dest_dict[k] for k in to_delete])
 
 
-def push_changes(diff, kinto_client, bucket, collection):
+def push_changes(diff, author_client, editor_client, reviewer_client,
+                 bucket, collection):
     to_create, to_update, to_delete = diff
 
     logger.warn('Syncing to {}{}'.format(
-        kinto_client.session.server_url,
-        kinto_client.endpoints.get(
+        author_client.session.server_url,
+        author_client.endpoints.get(
             'records', bucket=bucket, collection=collection)))
 
     logger.info('- {} records to create.'.format(len(to_create)))
     logger.info('- {} records to delete.'.format(len(to_delete)))
 
-    with kinto_client.batch(bucket=bucket, collection=collection) as batch:
+    with author_client.batch(bucket=bucket, collection=collection) as batch:
         for record in to_delete:
             batch.delete_record(record['id'])
         for record in to_create:
@@ -71,10 +72,11 @@ def push_changes(diff, kinto_client, bucket, collection):
             batch.patch_record(record)
 
     if to_create or to_update or to_delete:
-        logger.info('Trigger the signature.')
-
-        # Trigger signature once modifications where done.
-        kinto_client.patch_collection(data={'status': 'to-sign'},
-                                      bucket=bucket, collection=collection)
+        logger.info('Request review.')
+        editor_client.patch_collection(data={'status': 'to-review'},
+                                       bucket=bucket, collection=collection)
+        logger.info('Approve and trigger the signature.')
+        reviewer_client.patch_collection(data={'status': 'to-sign'},
+                                         bucket=bucket, collection=collection)
 
     logger.info('Done!')

--- a/amo2kinto/synchronize.py
+++ b/amo2kinto/synchronize.py
@@ -47,9 +47,15 @@ def get_diff(source, dest):
             [dest_dict[k] for k in to_delete])
 
 
-def push_changes(diff, author_client, editor_client, reviewer_client,
-                 bucket, collection):
+def push_changes(diff, author_client, bucket, collection,
+                 editor_client=None, reviewer_client=None):
     to_create, to_update, to_delete = diff
+
+    if editor_client is None:
+        editor_client = author_client
+
+    if reviewer_client is None:
+        reviewer_client = author_client
 
     logger.warn('Syncing to {}{}'.format(
         author_client.session.server_url,

--- a/amo2kinto/tests/test_importer.py
+++ b/amo2kinto/tests/test_importer.py
@@ -263,7 +263,9 @@ def test_sync_records_calls_the_scenario():
                          mock.sentinel.to_delete),
                         mock.sentinel.kinto_client,
                         bucket=mock.sentinel.bucket,
-                        collection=mock.sentinel.collection)
+                        collection=mock.sentinel.collection,
+                        editor_client=None,
+                        reviewer_client=None)
 
 
 SCHEMAS = {
@@ -375,6 +377,8 @@ class TestMain(unittest.TestCase):
             'amo_records': RECORDS['certificates'],
             'fields': FIELDS['certificates'],
             'kinto_client': kinto_client.return_value,
+            'editor_client': None,
+            'reviewer_client': None,
             'bucket': kwargs['certificates_bucket'],
             'collection': kwargs['certificates_collection'],
             'config': cert_config,
@@ -387,6 +391,8 @@ class TestMain(unittest.TestCase):
             'amo_records': RECORDS['gfx'],
             'fields': FIELDS['gfx'],
             'kinto_client': kinto_client.return_value,
+            'editor_client': None,
+            'reviewer_client': None,
             'bucket': kwargs['gfx_bucket'],
             'collection': kwargs['gfx_collection'],
             'config': gfx_config,
@@ -399,6 +405,8 @@ class TestMain(unittest.TestCase):
             'amo_records': RECORDS['addons'],
             'fields': FIELDS['addons'],
             'kinto_client': kinto_client.return_value,
+            'editor_client': None,
+            'reviewer_client': None,
             'bucket': kwargs['addons_bucket'],
             'collection': kwargs['addons_collection'],
             'config': addons_config,
@@ -411,6 +419,8 @@ class TestMain(unittest.TestCase):
             'amo_records': RECORDS['plugins'],
             'fields': FIELDS['plugins'],
             'kinto_client': kinto_client.return_value,
+            'editor_client': None,
+            'reviewer_client': None,
             'bucket': kwargs['plugins_bucket'],
             'collection': kwargs['plugins_collection'],
             'config': plugins_config,
@@ -518,6 +528,8 @@ class TestMain(unittest.TestCase):
             amo_records=RECORDS['certificates'],
             fields=FIELDS['certificates'],
             kinto_client=mock.ANY,
+            editor_client=mock.ANY,
+            reviewer_client=mock.ANY,
             bucket=constants.CERT_BUCKET,
             collection=constants.CERT_COLLECTION,
             config=None,
@@ -534,6 +546,8 @@ class TestMain(unittest.TestCase):
                 amo_records=RECORDS['certificates'],
                 fields=FIELDS['certificates'],
                 kinto_client=mock.ANY,
+                editor_client=mock.ANY,
+                reviewer_client=mock.ANY,
                 bucket=constants.CERT_BUCKET,
                 collection=constants.CERT_COLLECTION,
                 config=None,
@@ -542,8 +556,18 @@ class TestMain(unittest.TestCase):
                 amo_records=RECORDS['gfx'],
                 fields=FIELDS['gfx'],
                 kinto_client=mock.ANY,
+                editor_client=mock.ANY,
+                reviewer_client=mock.ANY,
                 bucket=constants.GFX_BUCKET,
                 collection=constants.GFX_COLLECTION,
                 config=None,
                 permissions=constants.COLLECTION_PERMISSIONS)],
             any_order=True)
+
+    def test_editor_auth_defines_editor_client(self):
+        with mock.patch('amo2kinto.importer.sync_records') as mock_sync:
+            main(['--editor-auth', 'editor-id:editor-password', '--no-schema'])
+
+    def test_reviewer_auth_defines_reviewer_client(self):
+        with mock.patch('amo2kinto.importer.sync_records') as mock_sync:
+            main(['--reviewer-auth', 'reviewer-id:reviewer-password', '--no-schema'])

--- a/amo2kinto/tests/test_importer.py
+++ b/amo2kinto/tests/test_importer.py
@@ -565,9 +565,45 @@ class TestMain(unittest.TestCase):
             any_order=True)
 
     def test_editor_auth_defines_editor_client(self):
-        with mock.patch('amo2kinto.importer.sync_records') as mock_sync:
-            main(['--editor-auth', 'editor-id:editor-password', '--no-schema'])
+        EditorClient = mock.MagicMock()
+        EditorClient._bucket_name = "staging"
+        EditorClient._collection_name = "qa"
+        EditorClient.return_value.session.request.return_value = {
+            'capabilities': {}
+        }, {}
+        with mock.patch('amo2kinto.importer.Client', EditorClient):
+            with mock.patch('amo2kinto.importer.sync_records') as mock_sync:
+                main(['--editor-auth', 'editor-id:editor-password', '--no-schema'])
+
+                mock_sync.assert_any_call(
+                    amo_records=RECORDS['certificates'],
+                    fields=FIELDS['certificates'],
+                    kinto_client=self.MockedClient.return_value,
+                    editor_client=EditorClient.return_value,
+                    reviewer_client=None,
+                    bucket=constants.CERT_BUCKET,
+                    collection=constants.CERT_COLLECTION,
+                    config=None,
+                    permissions=constants.COLLECTION_PERMISSIONS)
 
     def test_reviewer_auth_defines_reviewer_client(self):
-        with mock.patch('amo2kinto.importer.sync_records') as mock_sync:
-            main(['--reviewer-auth', 'reviewer-id:reviewer-password', '--no-schema'])
+        ReviewerClient = mock.MagicMock()
+        ReviewerClient._bucket_name = "staging"
+        ReviewerClient._collection_name = "qa"
+        ReviewerClient.return_value.session.request.return_value = {
+            'capabilities': {}
+        }, {}
+        with mock.patch('amo2kinto.importer.Client', ReviewerClient):
+            with mock.patch('amo2kinto.importer.sync_records') as mock_sync:
+                main(['--reviewer-auth', 'reviewer-id:reviewer-password', '--no-schema'])
+
+                mock_sync.assert_any_call(
+                    amo_records=RECORDS['certificates'],
+                    fields=FIELDS['certificates'],
+                    kinto_client=self.MockedClient.return_value,
+                    editor_client=None,
+                    reviewer_client=ReviewerClient.return_value,
+                    bucket=constants.CERT_BUCKET,
+                    collection=constants.CERT_COLLECTION,
+                    config=None,
+                    permissions=constants.COLLECTION_PERMISSIONS)


### PR DESCRIPTION
This allows amo2kinto importer to work when signoff workflows are enabled (or also when not enabled, since setting to `to-review` is a no-op.

@Natim we'll pair on this if you like :)