### PR TITLE
Stop sending cert blocklist items to Firefox 58 and later

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ This document describes changes between each past release.
 3.2.0 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Stop exporting cert items to Firefox 58 and above, where they aren't used. (#75)
 
 
 3.1.0 (2017-10-03)


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1435609 for context.

I could potentially expand the exception to other clients if we're sure that they don't care, either. Their versioning schemes are not the same and as a result I'm hesitant to ditch it. Though, as @mozmark said, older clients have bigger issues than the blocklist... so perhaps we should just ditch it unconditionally and remove the code + tests for it?

One other thing that I'm not sure about is how we'll force Firefox 60+ and later to update, given that they now use `Last-Modified` headers etc., and as far as I can tell from the test just prior to the one I added for this patch, we select the last item's last modified date, or something? I don't know if kinto or our blocklist-serving nginx server has other ways to effectively 'touch' the list when items are removed... But maybe I misunderstand that bit of the code, and/or what generates the header in this instance (which is clearly not the exporter itself). @leplatrem or @natim, perhaps you know?