### PR TITLE
open() files in binary if we're going to write bytes

### DIFF
--- a/amo2kinto/generator.py
+++ b/amo2kinto/generator.py
@@ -46,7 +46,7 @@ def generate_record(record, template, target_dir, get_filename):
     logger.info('Writing %s' % filename)
 
     # This needs to be able to write to S3
-    with open(filename, 'w') as f:
+    with open(filename, 'wb') as f:
         f.write(res.encode('utf-8'))
 
 

--- a/amo2kinto/generator.py
+++ b/amo2kinto/generator.py
@@ -35,8 +35,8 @@ def generate_index(records, template, target_dir):
     filename = os.path.join(target_dir, 'index.html')
 
     logger.info('Writing %s' % filename)
-    with open(filename, 'wb') as f:
-        f.write(res.encode('utf8'))
+    with open(filename, 'w', encoding='utf-8') as f:
+        f.write(res)
 
 
 def generate_record(record, template, target_dir, get_filename):
@@ -46,8 +46,8 @@ def generate_record(record, template, target_dir, get_filename):
     logger.info('Writing %s' % filename)
 
     # This needs to be able to write to S3
-    with open(filename, 'wb') as f:
-        f.write(res.encode('utf-8'))
+    with open(filename, 'w', encoding='utf-8') as f:
+        f.write(res)
 
 
 def get_record_filename(record):

--- a/amo2kinto/generator.py
+++ b/amo2kinto/generator.py
@@ -35,7 +35,7 @@ def generate_index(records, template, target_dir):
     filename = os.path.join(target_dir, 'index.html')
 
     logger.info('Writing %s' % filename)
-    with open(filename, 'w') as f:
+    with open(filename, 'wb') as f:
         f.write(res.encode('utf8'))
 
 

--- a/amo2kinto/tests/test_generator.py
+++ b/amo2kinto/tests/test_generator.py
@@ -121,7 +121,7 @@ def test_generate_record():
     with mock.patch('amo2kinto.generator.os.makedirs'):
         with mock.patch('amo2kinto.generator.open', f, create=True):
             generate_record(ADDONS_DATA, template, 'tmp', get_record_filename)
-            f.assert_called_once_with('tmp/i454.html', 'w')
+            f.assert_called_once_with('tmp/i454.html', 'wb')
             handle = f()
             assert handle.write.call_count == 1
 

--- a/amo2kinto/tests/test_generator.py
+++ b/amo2kinto/tests/test_generator.py
@@ -100,7 +100,7 @@ def test_generate_index():
     f = mock.mock_open()
     with mock.patch('amo2kinto.generator.open', f, create=True):
         generate_index(records, template, 'tmp')
-        f.assert_called_once_with('tmp/index.html', 'w')
+        f.assert_called_once_with('tmp/index.html', 'wb')
         handle = f()
         assert handle.write.call_count == 1
 
@@ -248,4 +248,4 @@ class TestMain(unittest.TestCase):
         main(['--target-dir', 'file'])
         self.assert_arguments(self.MockedClient)
 
-        self.mocked_open.assert_called_with('file/index.html', 'w')
+        self.mocked_open.assert_called_with('file/index.html', 'wb')

--- a/amo2kinto/tests/test_generator.py
+++ b/amo2kinto/tests/test_generator.py
@@ -100,7 +100,7 @@ def test_generate_index():
     f = mock.mock_open()
     with mock.patch('amo2kinto.generator.open', f, create=True):
         generate_index(records, template, 'tmp')
-        f.assert_called_once_with('tmp/index.html', 'wb')
+        f.assert_called_once_with('tmp/index.html', 'w', encoding='utf-8')
         handle = f()
         assert handle.write.call_count == 1
 
@@ -121,7 +121,7 @@ def test_generate_record():
     with mock.patch('amo2kinto.generator.os.makedirs'):
         with mock.patch('amo2kinto.generator.open', f, create=True):
             generate_record(ADDONS_DATA, template, 'tmp', get_record_filename)
-            f.assert_called_once_with('tmp/i454.html', 'wb')
+            f.assert_called_once_with('tmp/i454.html', 'w', encoding='utf-8')
             handle = f()
             assert handle.write.call_count == 1
 
@@ -167,10 +167,10 @@ def test_generate_uses_last_modified_if_created_is_missing():
             assert f.return_value.write.call_count == 2
 
             # Present in index
-            assert b'May 13, 2013' in f.return_value.write.call_args_list[0][0][0]
+            assert 'May 13, 2013' in f.return_value.write.call_args_list[0][0][0]
 
             # Present in the record file
-            assert b'May 13, 2013' in f.return_value.write.call_args_list[1][0][0]
+            assert 'May 13, 2013' in f.return_value.write.call_args_list[1][0][0]
 
 
 class TestMain(unittest.TestCase):
@@ -248,4 +248,4 @@ class TestMain(unittest.TestCase):
         main(['--target-dir', 'file'])
         self.assert_arguments(self.MockedClient)
 
-        self.mocked_open.assert_called_with('file/index.html', 'wb')
+        self.mocked_open.assert_called_with('file/index.html', 'w', encoding='utf-8')


### PR DESCRIPTION
This is meant to address #79. I'm not sure if there are other Python 3-related issues around this project -- this is just the first one we hit. The tests didn't catch it because they substitute a mock for the open() call.