### PR TITLE
Added if to the affected users section, minor page improvements

### DIFF
--- a/amo2kinto/templates/base.tpl
+++ b/amo2kinto/templates/base.tpl
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" dir="ltr">
+<html lang="en" dir="ltr">
   <head>
     <meta charset="utf-8">
     <title>Blocked Add-ons</title>
@@ -14,11 +14,11 @@
     <!--[if IE 7]><link rel="stylesheet" href="https://addons.cdn.mozilla.net/static/css/legacy/ie7.css"><![endif]-->
 
     <link rel="stylesheet" href="https://addons.cdn.mozilla.net/static/css/zamboni/blocklist.css">
-    <link rel="stylesheet" media="all" href="https://addons.cdn.mozilla.net/static/css/restyle/css-min.css?build=7dc09ff" />
+    <link rel="stylesheet" media="all" href="https://addons.cdn.mozilla.net/static/css/restyle/css-min.css?build=dd224a5" />
     <noscript><link rel="stylesheet" href="https://addons.cdn.mozilla.net/static/css/legacy/nojs.css"></noscript>
-    <script src="https://addons.cdn.mozilla.net/static/js/preload-min.js?build=b4f96d9-5706b886"></script>
+    <script src="https://addons.cdn.mozilla.net/static/js/preload-min.js?build=d97d82ed-5b34d014"></script>
   </head>
-  <body class="html-ltr firefox moz-header-slim  restyle">
+  <body class="html-ltr firefox moz-header-slim restyle">
       <div id="main-wrapper">
           <div id="background-wrapper"></div>
           <div class="section">
@@ -31,7 +31,7 @@
                           <div id="masthead">
                               <h1 class="site-title">
                                   <a href="./" title="Back to add-ons list.">
-                                      <img alt="" src="https://addons.cdn.mozilla.net/static/img/icons/firefox.png">
+                                      <img alt="" src="https://addons.cdn.mozilla.net/static/img/icons/firefox.png?b=d97d82ed-5b34d014">
                                       Blocked  Add-ons
                                   </a>
                               </h1>
@@ -43,7 +43,7 @@
                   </div>
               </div>
               <ol id="breadcrumbs" class="breadcrumbs">
-                  <li>Blocked add-ons</li>
+                  <li>Blocked Add-ons</li>
               </ol>
               {% block content %}{% endblock %}
               </div>
@@ -55,10 +55,9 @@
                   <ul>
                       <li>get to know <b>add-ons</b></li>
                       <li><a href="https://addons.mozilla.org/en-US/about">About</a></li>
-                      <li><a href="http://blog.mozilla.com/addons">Blog</a></li>
+                      <li><a href="https://blog.mozilla.org/addons/">Blog</a></li>
                       <li class="footer-devhub-link"><a href="https://addons.mozilla.org/en-US/developers/">Developer Hub</a></li>
-                      <li><a href="https://addons.mozilla.org/en-US/faq">FAQ</a></li>
-                      <li><a href="https://discourse.mozilla-community.org/c/add-ons">Forum</a></li>
+                      <li><a href="https://discourse.mozilla.org/c/add-ons">Forum</a></li>
                   </ul>
               </div>
               <div id="footer-content">
@@ -67,20 +66,19 @@
                           <a href="http://www.mozilla.org/privacy/websites/">
                               Privacy Policy
                           </a> &nbsp;|&nbsp;
-                          <a href="http://www.mozilla.org/about/legal.html">
+                          <a href="https://www.mozilla.org/about/legal/">
                               Legal Notices
                           </a> &nbsp;|&nbsp;
-                          <a href="http://www.mozilla.org/legal/fraud-report/index.html">
+                          <a href="https://www.mozilla.org/about/legal/fraud-report/">
                               Report Trademark Abuse
                           </a>
-                          &nbsp;|&nbsp;<a href="https://status.mozilla.org/#addons.mozilla.org_service_history">Site Status </a>
+                          &nbsp;|&nbsp;<a href="https://status.mozilla.org/">Site Status</a>
                       </p>
                       <p>
-                          Except where otherwise <a href="http://www.mozilla.org/about/legal.html#site">noted</a>, content on this site is licensed under the <br /> <a href="http://creativecommons.org/licenses/by-sa/3.0/"> Creative Commons Attribution Share-Alike License v3.0 </a> or any later version.  </p>
+                          Except where otherwise <a href="https://www.mozilla.org/about/legal/">noted</a>, content on this site is licensed under the <br /> <a href="https://creativecommons.org/licenses/by-sa/3.0/"> Creative Commons Attribution Share-Alike License v3.0 </a> or any later version.</p>
                   </div>
               </div>
           </div>
       </div>
   </body>
 </html>
-

--- a/amo2kinto/templates/record.tpl
+++ b/amo2kinto/templates/record.tpl
@@ -7,23 +7,24 @@
   <dl>
     <dt>Why was it blocked?</dt>
     <dd>{{ record.details.why|safe }}</dd>
+    {% if record.details.who %}
     <dt>Who is affected?</dt>
     <dd>{{ record.details.who|safe }}</dd>
+    {% endif %}
     <dt>What does this mean?</dt>
     <dd>
-	  {% if record.severity and record.severity == 1 %}
+      {% if record.severity and record.severity == 1 %}
       <p>
         Users are strongly encouraged to disable the problematic add-on or plugin,
         but may choose to continue using it if they accept the risks described.
       </p>
       {% else %}
       <p>
-        The problematic add-on or plugin will be automatically disabled and no
-        longer usable.
+        The problematic add-on or plugin will be automatically disabled and no longer usable.
       </p>
       {% endif %}
 
-    When Mozilla becomes aware of add-ons, plugins, or other third-party software that seriously compromises Firefox security, stability, or performance and meets <a href="http://wiki.mozilla.org/Blocklisting">certain criteria</a>, the software may be blocked from general use.  For more information, please read <a href="http://support.mozilla.org/kb/add-ons-cause-issues-are-on-blocklist">this support article</a>.</dd>
+    When Mozilla becomes aware of add-ons, plugins, or other third-party software that seriously compromises Firefox security, stability, or performance and meets <a href="https://wiki.mozilla.org/Blocklisting">certain criteria</a>, the software may be blocked from general use. For more information, please read <a href="https://support.mozilla.org/kb/add-ons-cause-issues-are-on-blocklist">this support article</a>.</dd>
   </dl>
    {% if record.details.bug %}
     <footer>Blocked on {{ record.details.created|datetime }}. <a href="{{ record.details.bug }}">View block request</a>.</footer>


### PR DESCRIPTION
Affected users section is often left blank, so if it's empty, it just stands out. Added an if around the section.

- The blocked add-ons page still uses the old Firefox logo, updated it
- Updated header/footer to update URLs to the current ones
- Fixed page language, it was set to fr/French
- Minor text changes